### PR TITLE
Make zstd dependency optional for WASM compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,20 +33,24 @@ flate2 = "1.0"
 serde_json = "1.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 brotli = "7.0"
-zstd = { version = "0.13.3", default-features = false }
 ahash = { version = "0.8.2", default-features = false, features = [
     "std",
     "no-rng",
 ] }
 futures = { version = "0.3.25", optional = true }
+# zstd feature omitted: zstd-sys (C code) cannot compile for wasm32
 async-compression = { version = "0.4.8", optional = true, features = [
     "futures-io",
-    "zstd",
     "gzip",
     "brotli",
 ] }
 duplicate = "1.0.0"
 async-recursion = { version = "1.0.4", optional = true }
+
+# zstd excluded on wasm32: zstd-sys requires C compilation
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+zstd = { version = "0.13.3", default-features = false }
+async-compression = { version = "0.4.8", optional = true, features = ["zstd"] }
 
 [dev-dependencies]
 temp-dir = "0.1"

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -66,12 +66,12 @@ pub struct Directory {
 
 impl Directory {
     /// Returns the number of entries in the directory, also referred to as its 'length'.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.entries.len()
     }
 
     /// Returns `true` if the directory contains no entries.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 

--- a/src/header/compression.rs
+++ b/src/header/compression.rs
@@ -23,6 +23,11 @@ pub enum Compression {
     Brotli,
 
     /// Zstandard Compression as defined in [RFC 8478](https://www.rfc-editor.org/rfc/rfc8478)
+    ///
+    /// <div class="warning">ZStd is not supported on <code>wasm32</code> targets. Passing this
+    /// variant to <a href="crate::util::compress"><code>compress</code></a>,
+    /// <a href="crate::util::decompress"><code>decompress</code></a>, or their async / <code>_all</code>
+    /// variants on a WASM target will return an <code>Err</code>.</div>
     ZStd,
 }
 

--- a/src/header/compression.rs
+++ b/src/header/compression.rs
@@ -24,10 +24,12 @@ pub enum Compression {
 
     /// Zstandard Compression as defined in [RFC 8478](https://www.rfc-editor.org/rfc/rfc8478)
     ///
-    /// <div class="warning">ZStd is not supported on <code>wasm32</code> targets. Passing this
-    /// variant to <a href="crate::util::compress"><code>compress</code></a>,
-    /// <a href="crate::util::decompress"><code>decompress</code></a>, or their async / <code>_all</code>
-    /// variants on a WASM target will return an <code>Err</code>.</div>
+    /// <div class="warning">
+    ///
+    /// Note that de-/compression of `ZStd` is not supported on `wasm32` targets. Passing this variant
+    /// to [`compress`](crate::util::compress), [`decompress`](crate::util::decompress), or their `_async` / `_all` variants on a WASM target will return an [`Err`].
+    ///
+    /// </div>
     ZStd,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::manual_div_ceil)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod directory;
 #[allow(clippy::ignored_unit_patterns)]

--- a/src/pmtiles.rs
+++ b/src/pmtiles.rs
@@ -134,7 +134,7 @@ impl<R> PMTiles<R> {
     /// Adds a tile to this `PMTiles` archive.
     ///
     /// Note that the data should already be compressed if [`Self::tile_compression`] is set to a value other than [`Compression::None`].
-    /// The data will **NOT** be compressed automatically.  
+    /// The data will **NOT** be compressed automatically. \
     /// The [`util`-module](crate::util) includes utilities to compress data.
     ///
     /// # Errors
@@ -159,7 +159,7 @@ impl<R: Read + Seek> PMTiles<R> {
     /// Get data of a tile by its id.
     ///
     /// The returned data is the raw data, meaning It is NOT uncompressed automatically,
-    /// if it was compressed in the first place.  
+    /// if it was compressed in the first place. \
     /// If you need the uncompressed data, take a look at the [`util`-module](crate::util)
     ///
     /// Will return [`Ok`] with an value of [`None`] if no a tile with the specified tile id was found.
@@ -190,7 +190,7 @@ impl<R: AsyncRead + AsyncReadExt + Send + Unpin + AsyncSeekExt> PMTiles<R> {
     /// Get data of a tile by its id.
     ///
     /// The returned data is the raw data, meaning It is NOT uncompressed automatically,
-    /// if it was compressed in the first place.  
+    /// if it was compressed in the first place. \
     /// If you need the uncompressed data, take a look at the [`util`-module](crate::util)
     ///
     /// Will return [`Ok`] with an value of [`None`] if no a tile with the specified tile id was found.
@@ -614,7 +614,7 @@ impl<R: AsyncRead + AsyncSeekExt + Send + Unpin> PMTiles<R> {
     /// ```
     pub async fn from_async_reader_partially(
         input: R,
-        tiles_filter_range: (impl RangeBounds<u64> + Sync + Send),
+        tiles_filter_range: impl RangeBounds<u64> + Sync + Send,
     ) -> Result<Self> {
         Self::from_async_reader_impl(input, tiles_filter_range).await
     }
@@ -963,13 +963,13 @@ mod test {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Unwritten test case."]
     fn test_to_writer() -> Result<()> {
         todo!()
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Unwritten test case."]
     fn test_to_writer_with_leaf_directories() -> Result<()> {
         todo!()
     }

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -1,18 +1,13 @@
 use crate::Compression;
 
-#[cfg(feature = "async")]
-use async_compression::futures::{
-    bufread::{
-        BrotliDecoder as AsyncBrotliDecoder, GzipDecoder as AsyncGzipDecoder,
-    },
-    write::{
-        BrotliEncoder as AsyncBrotliEncoder, GzipEncoder as AsyncGzipEncoder,
-    },
-};
 #[cfg(all(feature = "async", not(target_arch = "wasm32")))]
 use async_compression::futures::{
-    bufread::ZstdDecoder as AsyncZstdDecoder,
-    write::ZstdEncoder as AsyncZstdEncoder,
+    bufread::ZstdDecoder as AsyncZstdDecoder, write::ZstdEncoder as AsyncZstdEncoder,
+};
+#[cfg(feature = "async")]
+use async_compression::futures::{
+    bufread::{BrotliDecoder as AsyncBrotliDecoder, GzipDecoder as AsyncGzipDecoder},
+    write::{BrotliEncoder as AsyncBrotliEncoder, GzipEncoder as AsyncGzipEncoder},
 };
 use brotli::{CompressorWriter as BrotliEncoder, Decompressor as BrotliDecoder};
 use flate2::{read::GzDecoder, write::GzEncoder};
@@ -72,7 +67,7 @@ pub fn compress<'a>(
                     "ZStd compression is not supported on WASM targets",
                 ))
             }
-        },
+        }
     }
 }
 
@@ -129,7 +124,7 @@ pub fn compress_async<'a>(
                     "ZStd compression is not supported on WASM targets",
                 ))
             }
-        },
+        }
     }
 }
 
@@ -203,7 +198,7 @@ pub fn decompress<'a>(
                     "ZStd decompression is not supported on WASM targets",
                 ))
             }
-        },
+        }
     }
 }
 
@@ -239,7 +234,9 @@ pub fn decompress_async<'a>(
         Compression::ZStd => {
             #[cfg(not(target_arch = "wasm32"))]
             {
-                Ok(Box::new(AsyncZstdDecoder::new(BufReader::new(compressed_data))))
+                Ok(Box::new(AsyncZstdDecoder::new(BufReader::new(
+                    compressed_data,
+                ))))
             }
             #[cfg(target_arch = "wasm32")]
             {
@@ -248,7 +245,7 @@ pub fn decompress_async<'a>(
                     "ZStd decompression is not supported on WASM targets",
                 ))
             }
-        },
+        }
     }
 }
 

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -22,18 +22,22 @@ use std::io::{Cursor, Error, Read, Result, Write};
 
 /// Returns a new instance of [`std::io::Write`] that will emit compressed data to the underlying writer.
 ///
+/// <div class="warning">
+///
+///  `ZStd` is not supported on `wasm32` targets. Passing
+/// [`Compression::ZStd`] on a WASM target will return an [`Err`] .
+///
+/// </div>
+///
 /// # Arguments
 /// * `compression` - Compression to use
 /// * `writer` - Underlying writer to write compressed data to
 ///
 /// # Errors
-/// Will return [`Err`] if `compression` is set to [`Compression::Unknown`] or an error occurred
-/// while creating the zstd encoder.
-///
-/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
-/// is not supported on <code>wasm32</code> targets and will return an
-/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
-/// on those targets.</div>
+/// Will return [`Err`] if...
+/// - `compression` is set to [`Compression::Unknown`]
+/// - `compression` is set to [`Compression::ZStd`] on a WASM target
+/// - there was an error while creating the zstd encoder
 ///
 /// # Example
 /// ```rust
@@ -79,18 +83,22 @@ pub fn compress<'a>(
 ///
 /// Returns a new instance of [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) that will emit compressed data to the underlying writer.
 ///
+/// <div class="warning">
+///
+///  `ZStd` is not supported on `wasm32` targets. Passing
+/// [`Compression::ZStd`] on a WASM target will return an [`Err`] .
+///
+/// </div>
+///
 /// # Arguments
 /// * `compression` - Compression to use
 /// * `writer` - Underlying writer to write compressed data to
 ///
 /// # Errors
-/// Will return [`Err`] if `compression` is set to [`Compression::Unknown`] or an error occurred
-/// while creating the zstd encoder.
-///
-/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
-/// is not supported on <code>wasm32</code> targets and will return an
-/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
-/// on those targets.</div>
+/// Will return [`Err`] if...
+/// - `compression` is set to [`Compression::Unknown`]
+/// - `compression` is set to [`Compression::ZStd`] on a WASM target
+/// - there was an error while creating the zstd encoder
 ///
 /// # Example
 /// ```rust
@@ -136,18 +144,24 @@ pub fn compress_async<'a>(
 
 /// Compresses a byte slice and returns the result as a new [`Vec<u8>`].
 ///
+/// <div class="warning">
+///
+///  `ZStd` is not supported on `wasm32` targets. Passing
+/// [`Compression::ZStd`] on a WASM target will return an [`Err`] .
+///
+/// </div>
+///
 /// # Arguments
 /// * `compression` - Compression to use
 /// * `data` - Data to compress
 ///
 /// # Errors
-/// Will return [`Err`] if `compression` is set to [`Compression::Unknown`], there was an error
-/// while creating the zstd encoder or an error occurred while writing to `data`.
+/// Will return [`Err`] if...
+/// - `compression` is set to [`Compression::Unknown`]
+/// - `compression` is set to [`Compression::ZStd`] on a WASM target
+/// - there was an error while creating the zstd encoder
+/// - there was an error occurred while writing to `data`.
 ///
-/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
-/// is not supported on <code>wasm32</code> targets and will return an
-/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
-/// on those targets.</div>
 #[allow(clippy::module_name_repetitions)]
 pub fn compress_all(compression: Compression, data: &[u8]) -> Result<Vec<u8>> {
     let mut destination = Vec::<u8>::new();
@@ -165,18 +179,22 @@ pub fn compress_all(compression: Compression, data: &[u8]) -> Result<Vec<u8>> {
 
 /// Returns a new instance of [`std::io::Read`] that will emit uncompressed data from an the underlying reader.
 ///
+/// <div class="warning">
+///
+///  `ZStd` is not supported on `wasm32` targets. Passing
+/// [`Compression::ZStd`] on a WASM target will return an [`Err`] .
+///
+/// </div>
+///
 /// # Arguments
 /// * `compression` - Compression to use
 /// * `compressed_data` - Underlying reader with compressed data
 ///
 /// # Errors
-/// Will return [`Err`] if `compression` is set to [`Compression::Unknown`],there was an
-/// error while creating the zstd decoder.
-///
-/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
-/// is not supported on <code>wasm32</code> targets and will return an
-/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
-/// on those targets.</div>
+/// Will return [`Err`] if...
+/// - `compression` is set to [`Compression::Unknown`]
+/// - `compression` is set to [`Compression::ZStd`] on a WASM target
+/// - there was an error while creating the zstd decoder
 ///
 /// # Example
 /// ```rust
@@ -219,18 +237,22 @@ pub fn decompress<'a>(
 ///
 /// Returns a new instance of [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) that will emit uncompressed data from an the underlying reader.
 ///
+/// <div class="warning">
+///
+///  `ZStd` is not supported on `wasm32` targets. Passing
+/// [`Compression::ZStd`] on a WASM target will return an [`Err`] .
+///
+/// </div>
+///
 /// # Arguments
 /// * `compression` - Compression to use
 /// * `compressed_data` - Underlying reader with compressed data
 ///
 /// # Errors
-/// Will return [`Err`] if `compression` is set to [`Compression::Unknown`],there was an
-/// error while creating the zstd decoder.
-///
-/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
-/// is not supported on <code>wasm32</code> targets and will return an
-/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
-/// on those targets.</div>
+/// Will return [`Err`] if...
+/// - `compression` is set to [`Compression::Unknown`]
+/// - `compression` is set to [`Compression::ZStd`] on a WASM target
+/// - there was an error while creating the zstd decoder
 ///
 #[cfg(feature = "async")]
 pub fn decompress_async<'a>(
@@ -266,6 +288,13 @@ pub fn decompress_async<'a>(
 
 /// Decompresses a byte slice and returns the result as a new [`Vec<u8>`].
 ///
+/// <div class="warning">
+///
+///  `ZStd` is not supported on `wasm32` targets. Passing
+/// [`Compression::ZStd`] on a WASM target will return an [`Err`] .
+///
+/// </div>
+///
 /// # Arguments
 /// * `compression` - Compression to use
 /// * `data` - Data to decompress
@@ -273,14 +302,11 @@ pub fn decompress_async<'a>(
 /// # Errors
 /// Will return [`Err`] if...
 /// - `compression` is set to [`Compression::Unknown`]
+/// - `compression` is set to [`Compression::ZStd`] on a WASM target
 /// - there was an error while creating the zstd decoder
 /// - there was an error reading the `data`
 /// - `data` is not compressed correctly
 ///
-/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
-/// is not supported on <code>wasm32</code> targets and will return an
-/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
-/// on those targets.</div>
 pub fn decompress_all(compression: Compression, data: &[u8]) -> Result<Vec<u8>> {
     let mut data_reader = Cursor::new(data);
 

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -4,17 +4,21 @@ use crate::Compression;
 use async_compression::futures::{
     bufread::{
         BrotliDecoder as AsyncBrotliDecoder, GzipDecoder as AsyncGzipDecoder,
-        ZstdDecoder as AsyncZstdDecoder,
     },
     write::{
         BrotliEncoder as AsyncBrotliEncoder, GzipEncoder as AsyncGzipEncoder,
-        ZstdEncoder as AsyncZstdEncoder,
     },
+};
+#[cfg(all(feature = "async", not(target_arch = "wasm32")))]
+use async_compression::futures::{
+    bufread::ZstdDecoder as AsyncZstdDecoder,
+    write::ZstdEncoder as AsyncZstdEncoder,
 };
 use brotli::{CompressorWriter as BrotliEncoder, Decompressor as BrotliDecoder};
 use flate2::{read::GzDecoder, write::GzEncoder};
 #[cfg(feature = "async")]
 use futures::{io::BufReader, AsyncRead, AsyncWrite};
+#[cfg(not(target_arch = "wasm32"))]
 use zstd::{Decoder as ZSTDDecoder, Encoder as ZSTDEncoder};
 
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Write};
@@ -56,7 +60,19 @@ pub fn compress<'a>(
             flate2::Compression::default(),
         ))),
         Compression::Brotli => Ok(Box::new(BrotliEncoder::new(writer, 4096, 11, 24))),
-        Compression::ZStd => Ok(Box::new(ZSTDEncoder::new(writer, 0)?.auto_finish())),
+        Compression::ZStd => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Ok(Box::new(ZSTDEncoder::new(writer, 0)?.auto_finish()))
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                Err(Error::new(
+                    ErrorKind::Unsupported,
+                    "ZStd compression is not supported on WASM targets",
+                ))
+            }
+        },
     }
 }
 
@@ -101,7 +117,19 @@ pub fn compress_async<'a>(
         Compression::None => Ok(Box::new(writer)),
         Compression::GZip => Ok(Box::new(AsyncGzipEncoder::new(writer))),
         Compression::Brotli => Ok(Box::new(AsyncBrotliEncoder::new(writer))),
-        Compression::ZStd => Ok(Box::new(AsyncZstdEncoder::new(writer))),
+        Compression::ZStd => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Ok(Box::new(AsyncZstdEncoder::new(writer)))
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                Err(Error::new(
+                    ErrorKind::Unsupported,
+                    "ZStd compression is not supported on WASM targets",
+                ))
+            }
+        },
     }
 }
 
@@ -163,7 +191,19 @@ pub fn decompress<'a>(
         Compression::None => Ok(Box::new(compressed_data)),
         Compression::GZip => Ok(Box::new(GzDecoder::new(compressed_data))),
         Compression::Brotli => Ok(Box::new(BrotliDecoder::new(compressed_data, 4096))),
-        Compression::ZStd => Ok(Box::new(ZSTDDecoder::new(compressed_data)?)),
+        Compression::ZStd => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Ok(Box::new(ZSTDDecoder::new(compressed_data)?))
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                Err(Error::new(
+                    ErrorKind::Unsupported,
+                    "ZStd decompression is not supported on WASM targets",
+                ))
+            }
+        },
     }
 }
 
@@ -196,9 +236,19 @@ pub fn decompress_async<'a>(
         Compression::Brotli => Ok(Box::new(AsyncBrotliDecoder::new(BufReader::new(
             compressed_data,
         )))),
-        Compression::ZStd => Ok(Box::new(AsyncZstdDecoder::new(BufReader::new(
-            compressed_data,
-        )))),
+        Compression::ZStd => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Ok(Box::new(AsyncZstdDecoder::new(BufReader::new(compressed_data))))
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                Err(Error::new(
+                    ErrorKind::Unsupported,
+                    "ZStd decompression is not supported on WASM targets",
+                ))
+            }
+        },
     }
 }
 

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -16,7 +16,7 @@ use futures::{io::BufReader, AsyncRead, AsyncWrite};
 #[cfg(not(target_arch = "wasm32"))]
 use zstd::{Decoder as ZSTDDecoder, Encoder as ZSTDEncoder};
 
-use std::io::{Cursor, Error, ErrorKind, Read, Result, Write};
+use std::io::{Cursor, Error, Read, Result, Write};
 
 /// Returns a new instance of [`std::io::Write`] that will emit compressed data to the underlying writer.
 ///
@@ -27,6 +27,11 @@ use std::io::{Cursor, Error, ErrorKind, Read, Result, Write};
 /// # Errors
 /// Will return [`Err`] if `compression` is set to [`Compression::Unknown`] or an error occurred
 /// while creating the zstd encoder.
+///
+/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
+/// is not supported on <code>wasm32</code> targets and will return an
+/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
+/// on those targets.</div>
 ///
 /// # Example
 /// ```rust
@@ -45,8 +50,7 @@ pub fn compress<'a>(
     writer: &'a mut impl Write,
 ) -> Result<Box<dyn Write + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::new(
-            ErrorKind::Other,
+        Compression::Unknown => Err(Error::other(
             "Cannot compress for Compression Unknown",
         )),
         Compression::None => Ok(Box::new(writer)),
@@ -83,6 +87,11 @@ pub fn compress<'a>(
 /// Will return [`Err`] if `compression` is set to [`Compression::Unknown`] or an error occurred
 /// while creating the zstd encoder.
 ///
+/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
+/// is not supported on <code>wasm32</code> targets and will return an
+/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
+/// on those targets.</div>
+///
 /// # Example
 /// ```rust
 /// # use futures::io::{AsyncWriteExt};
@@ -105,8 +114,7 @@ pub fn compress_async<'a>(
     writer: &'a mut (impl AsyncWrite + Unpin + Send),
 ) -> Result<Box<dyn AsyncWrite + Unpin + Send + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::new(
-            ErrorKind::Other,
+        Compression::Unknown => Err(Error::other(
             "Cannot compress for Compression Unknown",
         )),
         Compression::None => Ok(Box::new(writer)),
@@ -137,6 +145,11 @@ pub fn compress_async<'a>(
 /// # Errors
 /// Will return [`Err`] if `compression` is set to [`Compression::Unknown`], there was an error
 /// while creating the zstd encoder or an error occurred while writing to `data`.
+///
+/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
+/// is not supported on <code>wasm32</code> targets and will return an
+/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
+/// on those targets.</div>
 #[allow(clippy::module_name_repetitions)]
 pub fn compress_all(compression: Compression, data: &[u8]) -> Result<Vec<u8>> {
     let mut destination = Vec::<u8>::new();
@@ -162,6 +175,11 @@ pub fn compress_all(compression: Compression, data: &[u8]) -> Result<Vec<u8>> {
 /// Will return [`Err`] if `compression` is set to [`Compression::Unknown`],there was an
 /// error while creating the zstd decoder.
 ///
+/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
+/// is not supported on <code>wasm32</code> targets and will return an
+/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
+/// on those targets.</div>
+///
 /// # Example
 /// ```rust
 /// # use pmtiles2::{util::decompress, Compression};
@@ -179,8 +197,7 @@ pub fn decompress<'a>(
     compressed_data: &'a mut impl Read,
 ) -> Result<Box<dyn Read + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::new(
-            ErrorKind::Other,
+        Compression::Unknown => Err(Error::other(
             "Cannot decompress for Compression Unknown",
         )),
         Compression::None => Ok(Box::new(compressed_data)),
@@ -214,14 +231,18 @@ pub fn decompress<'a>(
 /// Will return [`Err`] if `compression` is set to [`Compression::Unknown`],there was an
 /// error while creating the zstd decoder.
 ///
+/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
+/// is not supported on <code>wasm32</code> targets and will return an
+/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
+/// on those targets.</div>
+///
 #[cfg(feature = "async")]
 pub fn decompress_async<'a>(
     compression: Compression,
     compressed_data: &'a mut (impl AsyncRead + Unpin + Send),
 ) -> Result<Box<dyn AsyncRead + Unpin + Send + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::new(
-            ErrorKind::Other,
+        Compression::Unknown => Err(Error::other(
             "Cannot decompress for Compression Unknown",
         )),
         Compression::None => Ok(Box::new(compressed_data)),
@@ -262,6 +283,10 @@ pub fn decompress_async<'a>(
 /// - there was an error reading the `data`
 /// - `data` is not compressed correctly
 ///
+/// <div class="warning"><a href="crate::Compression::ZStd"><code>Compression::ZStd</code></a>
+/// is not supported on <code>wasm32</code> targets and will return an
+/// <a href="std::io::ErrorKind::Unsupported"><code>Err(ErrorKind::Unsupported)</code></a>
+/// on those targets.</div>
 pub fn decompress_all(compression: Compression, data: &[u8]) -> Result<Vec<u8>> {
     let mut data_reader = Cursor::new(data);
 

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -16,9 +16,9 @@ use futures::{io::BufReader, AsyncRead, AsyncWrite};
 #[cfg(not(target_arch = "wasm32"))]
 use zstd::{Decoder as ZSTDDecoder, Encoder as ZSTDEncoder};
 
-use std::io::{Cursor, Error, Read, Result, Write};
 #[cfg(target_arch = "wasm32")]
 use std::io::ErrorKind;
+use std::io::{Cursor, Error, Read, Result, Write};
 
 /// Returns a new instance of [`std::io::Write`] that will emit compressed data to the underlying writer.
 ///
@@ -52,9 +52,7 @@ pub fn compress<'a>(
     writer: &'a mut impl Write,
 ) -> Result<Box<dyn Write + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::other(
-            "Cannot compress for Compression Unknown",
-        )),
+        Compression::Unknown => Err(Error::other("Cannot compress for Compression Unknown")),
         Compression::None => Ok(Box::new(writer)),
         Compression::GZip => Ok(Box::new(GzEncoder::new(
             writer,
@@ -116,9 +114,7 @@ pub fn compress_async<'a>(
     writer: &'a mut (impl AsyncWrite + Unpin + Send),
 ) -> Result<Box<dyn AsyncWrite + Unpin + Send + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::other(
-            "Cannot compress for Compression Unknown",
-        )),
+        Compression::Unknown => Err(Error::other("Cannot compress for Compression Unknown")),
         Compression::None => Ok(Box::new(writer)),
         Compression::GZip => Ok(Box::new(AsyncGzipEncoder::new(writer))),
         Compression::Brotli => Ok(Box::new(AsyncBrotliEncoder::new(writer))),
@@ -199,9 +195,7 @@ pub fn decompress<'a>(
     compressed_data: &'a mut impl Read,
 ) -> Result<Box<dyn Read + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::other(
-            "Cannot decompress for Compression Unknown",
-        )),
+        Compression::Unknown => Err(Error::other("Cannot decompress for Compression Unknown")),
         Compression::None => Ok(Box::new(compressed_data)),
         Compression::GZip => Ok(Box::new(GzDecoder::new(compressed_data))),
         Compression::Brotli => Ok(Box::new(BrotliDecoder::new(compressed_data, 4096))),
@@ -244,9 +238,7 @@ pub fn decompress_async<'a>(
     compressed_data: &'a mut (impl AsyncRead + Unpin + Send),
 ) -> Result<Box<dyn AsyncRead + Unpin + Send + 'a>> {
     match compression {
-        Compression::Unknown => Err(Error::other(
-            "Cannot decompress for Compression Unknown",
-        )),
+        Compression::Unknown => Err(Error::other("Cannot decompress for Compression Unknown")),
         Compression::None => Ok(Box::new(compressed_data)),
         Compression::GZip => Ok(Box::new(AsyncGzipDecoder::new(BufReader::new(
             compressed_data,

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -17,6 +17,8 @@ use futures::{io::BufReader, AsyncRead, AsyncWrite};
 use zstd::{Decoder as ZSTDDecoder, Encoder as ZSTDEncoder};
 
 use std::io::{Cursor, Error, Read, Result, Write};
+#[cfg(target_arch = "wasm32")]
+use std::io::ErrorKind;
 
 /// Returns a new instance of [`std::io::Write`] that will emit compressed data to the underlying writer.
 ///

--- a/src/util/read_directories.rs
+++ b/src/util/read_directories.rs
@@ -116,7 +116,7 @@ pub async fn read_directories_async(
     compression: Compression,
     root_dir_offset_length: (u64, u64),
     leaf_dir_offset: u64,
-    filter_range: (impl RangeBounds<u64> + Sync + Send),
+    filter_range: impl RangeBounds<u64> + Sync + Send,
 ) -> Result<HashMap<u64, OffsetLength, RandomState>> {
     let mut tiles = HashMap::<u64, OffsetLength, RandomState>::default();
 


### PR DESCRIPTION
The zstd dependency (via zstd-sys) requires C compilation and cannot be compiled for wasm32-unknown-unknown. I am using this crate for an application that requires web-assembly, so this PR makes zstd conditional on non-wasm32 targets, allowing the crate to be compiled for wasm environments.

Changes:
- Cargo.toml: moved zstd and the zstd feature of async-compression to [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
- compress.rs: gated all zstd encode/decode paths with #[cfg(not(target_arch = "wasm32"))]; returns ErrorKind::Unsupported on WASM targets

All existing tests pass. There is no intended behavior change on non-wasm targets.
